### PR TITLE
Update _objects.layout.scss

### DIFF
--- a/_objects.layout.scss
+++ b/_objects.layout.scss
@@ -15,6 +15,7 @@
  */
 
 @import 'px-defaults-design/_settings.defaults.scss';
+@import "inuit-responsive-settings/_settings.responsive.scss";
 @import 'inuit-responsive-tools/_tools.responsive.scss';
 
 /// @type String [default] - Prepend value for all generated classes


### PR DESCRIPTION
See the commit comment. This eliminates a warning I am seeing when using px-*-design with Angular 2 CLI / node-sass. Not sure if this warning is seen when using predix-seed SASS tooling ... (If not, it may be worth checking why not ...)
